### PR TITLE
fix crash when going from game over -> main menu

### DIFF
--- a/src/api_helper_functions.lua
+++ b/src/api_helper_functions.lua
@@ -24,12 +24,14 @@ JokerDisplay.evaluate_hand = function(cards, count_facedowns)
     end
 
     -- To prevent crashing during poker hand eval
-    if G.play then
+    if G.play and G.play.cards then
         for i = 1, #G.play.cards do
             if type(G.play.cards[i]) ~= "table" or not G.play.cards[i].ability or not (G.play.cards[i].ability.set == 'Enhanced' or G.play.cards[i].ability.set == 'Default') then
                 return "Unknown", {}, {}
             end
         end
+    else
+        return "Unknown", {}, {}
     end
 
     if not count_facedowns then


### PR DESCRIPTION
The current mod code is crashing for me when going from a losing Game Over screen to the Main Menu (by clicking on "Main Menu").

This fixes it.

Note: Tbh, I don't fully understand what's happening in this `evaluate_hand` function (and why it's even called when going to the main menu), should double-check that this doesn't break other functionality by early returning.