### PR TITLE
Optimization

### DIFF
--- a/src/api_helper_functions.lua
+++ b/src/api_helper_functions.lua
@@ -123,15 +123,21 @@ JokerDisplay.copy_display = function(card, copied_joker, is_debuffed, bypass_deb
     card.joker_display_values.blueprint_force_update = true
 
     if card.joker_display_values.blueprint_initialized and (changed or not card.joker_display_values.blueprint_loaded) then
-        card.children.joker_display:remove_text()
-        card.children.joker_display:remove_reminder_text()
-        card.children.joker_display:remove_extra()
-        card.children.joker_display_small:remove_text()
-        card.children.joker_display_small:remove_reminder_text()
-        card.children.joker_display_small:remove_extra()
+        if card.children.joker_display then            
+            card.children.joker_display:remove_text()
+            card.children.joker_display:remove_reminder_text()
+            card.children.joker_display:remove_extra()
+        end
+        if card.children.joker_display_small then
+            card.children.joker_display_small:remove_text()
+            card.children.joker_display_small:remove_reminder_text()
+            card.children.joker_display_small:remove_extra()
+        end
         if copied_joker then
             if card.joker_display_values.blueprint_debuff then
-                card.children.joker_display:add_text({ { text = "" .. localize("k_debuffed"), colour = G.C.UI.TEXT_INACTIVE } })
+                if card.children.joker_display then
+                    card.children.joker_display:add_text({ { text = "" .. localize("k_debuffed"), colour = G.C.UI.TEXT_INACTIVE } })
+                end
             elseif copied_joker.joker_display_values then
                 copied_joker:initialize_joker_display(card)
                 card.joker_display_values.blueprint_loaded = true

--- a/src/api_helper_functions.lua
+++ b/src/api_helper_functions.lua
@@ -218,9 +218,9 @@ JokerDisplay.calculate_card_triggers = function(card, scoring_hand, held_in_hand
 
     local triggers = 1
 
-    if G.jokers then
-        for _, area in ipairs(JokerDisplay.get_display_areas()) do
-            for _, joker in pairs(area.cards) do
+    if JokerDisplay.should_display() then
+        for _, area in pairs(JokerDisplay.get_display_areas()) do
+            for _, joker in pairs(area.cards or {}) do
                 local joker_display_definition = JokerDisplay.Definitions[joker.config.center.key]
                 local retrigger_function = not joker.debuff and joker.joker_display_values and
                     ((joker_display_definition and joker_display_definition.retrigger_function) or
@@ -281,9 +281,9 @@ JokerDisplay.calculate_joker_modifiers = function(card)
         end
     end
 
-    if G.jokers then
-        for _, area in ipairs(JokerDisplay.get_display_areas()) do
-            for _, joker in pairs(area.cards) do
+    if JokerDisplay.should_display() then
+        for _, area in pairs(JokerDisplay.get_display_areas()) do
+            for _, joker in pairs(area.cards or {}) do
                 local joker_display_definition = JokerDisplay.Definitions[joker.config.center.key]
                 local mod_function = not joker.debuff and joker.joker_display_values and
                     ((joker_display_definition and joker_display_definition.mod_function) or
@@ -354,9 +354,9 @@ JokerDisplay.calculate_joker_triggers = function(card)
 
     local triggers = 1
 
-    if G.jokers then
-        for _, area in ipairs(JokerDisplay.get_display_areas()) do
-            for _, joker in pairs(area.cards) do
+    if JokerDisplay.should_display() then
+        for _, area in pairs(JokerDisplay.get_display_areas()) do
+            for _, joker in pairs(area.cards or {}) do
                 local joker_display_definition = JokerDisplay.Definitions[joker.config.center.key]
                 local retrigger_joker_function = not joker.debuff and joker.joker_display_values and
                     ((joker_display_definition and joker_display_definition.retrigger_joker_function) or

--- a/src/config_tab.lua
+++ b/src/config_tab.lua
@@ -13,17 +13,25 @@ JokerDisplay.save_config = JokerDisplay.save_config or function() end
 JokerDisplay.config_tab = function()
     if not JokerDisplay.init_loc then init_localization() end
     -- Create a card area that will display an example joker
-    G.config_card_area = CardArea(G.ROOM.T.x + 0.2 * G.ROOM.T.w / 2, G.ROOM.T.h, 1.03 * G.CARD_W, 1.03 * G.CARD_H,
+    G.jokerdisplay_config_card_area = CardArea(G.ROOM.T.x + 0.2 * G.ROOM.T.w / 2, G.ROOM.T.h, 1.03 * G.CARD_W, 1.03 * G.CARD_H,
         { card_limit = 1, type = 'title', highlight_limit = 0, })
     local center = G.P_CENTERS['j_bloodstone']
-    local card = Card(G.config_card_area.T.x + G.config_card_area.T.w / 2, G.config_card_area.T.y, G.CARD_W, G.CARD_H,
+    local card = Card(G.jokerdisplay_config_card_area.T.x + G.jokerdisplay_config_card_area.T.w / 2, G.jokerdisplay_config_card_area.T.y, G.CARD_W, G.CARD_H,
         nil, center)
     card:set_edition('e_foil', true, true)
     card:set_perishable(true)
     card:set_rental(true)
-    G.config_card_area:emplace(card)
-    G.config_card_area.cards[1]:update_joker_display()
-    G.config_card_area.cards[1].joker_display_values.disabled = false
+    G.jokerdisplay_config_card_area:emplace(card)
+    G.jokerdisplay_config_card_area.cards[1]:update_joker_display()
+    G.jokerdisplay_config_card_area.cards[1].joker_display_values.disabled = false
+
+    local old_remove = G.jokerdisplay_config_card_area.remove
+    function G.jokerdisplay_config_card_area:remove()
+        old_remove(self)
+        if G.jokerdisplay_config_card_area == self then
+            G.jokerdisplay_config_card_area = nil
+        end
+    end
 
     local modNodes = {}
 
@@ -283,7 +291,7 @@ JokerDisplay.config_tab = function()
                     n = G.UIT.C,
                     config = { align = "tm", padding = 0.1, no_fill = true },
                     nodes = {
-                        { n = G.UIT.O, config = { object = G.config_card_area } }
+                        { n = G.UIT.O, config = { object = G.jokerdisplay_config_card_area } }
                     }
                 }
             }
@@ -368,11 +376,13 @@ end
 function update_display()
     JokerDisplay.save_config()
 
-    G.config_card_area.cards[1]:update_joker_display(false, true, "config_update")
-    if G.jokers then
-        for _, area in ipairs(JokerDisplay.get_display_areas()) do
-            for _, joker in pairs(area.cards) do
-                joker:update_joker_display(false, true, "config_update")
+    if G.jokerdisplay_config_card_area then
+        G.jokerdisplay_config_card_area.cards[1]:update_joker_display(true, true, "config_update")
+    end
+    if JokerDisplay.should_display() then
+        for _, area in pairs(JokerDisplay.get_display_areas()) do
+            for _, joker in pairs(area.cards or {}) do
+                joker:update_joker_display(true, true, "config_update")
             end
         end
     end

--- a/src/controller.lua
+++ b/src/controller.lua
@@ -19,10 +19,10 @@ function Controller:queue_R_cursor_press(x, y)
     local press_node = self.hovering.target or self.focused.target
     if not JokerDisplay.config.shift_to_hide or love.keyboard.isDown('lshift') or love.keyboard.isDown('rshift') then
         if not G.SETTINGS.paused then
-            if press_node and G.jokers then
+            if press_node and JokerDisplay.should_display() then
                 local is_display_area = false
                 if press_node.area then
-                    for _, area in ipairs(JokerDisplay.get_display_areas()) do
+                    for _, area in pairs(JokerDisplay.get_display_areas()) do
                         if press_node.area == area then
                             is_display_area = true
                             break
@@ -51,11 +51,11 @@ local controller_button_press_update_ref = Controller.button_press_update
 function Controller:button_press_update(button, dt)
     controller_button_press_update_ref(self, button, dt)
 
-    if G.jokers then
+    if JokerDisplay.should_display() then
         local press_node = self.hovering.target or self.focused.target
         local is_display_area = false
         if press_node and press_node.area then
-            for _, area in ipairs(JokerDisplay.get_display_areas()) do
+            for _, area in pairs(JokerDisplay.get_display_areas()) do
                 if press_node.area == area then
                     is_display_area = true
                     break

--- a/src/controller.lua
+++ b/src/controller.lua
@@ -7,7 +7,13 @@ function Controller:queue_L_cursor_press(x, y)
     local press_node = self.hovering.target or self.focused.target
     if press_node and press_node.name and press_node.name == "JokerDisplay" and press_node.can_collapse and press_node.parent then
         if not JokerDisplay.config.disable_collapse and not press_node.parent.joker_display_values.disabled then
-            press_node.parent.joker_display_values.small = not press_node.parent.joker_display_values.small
+            local card = press_node.parent
+            card.joker_display_values.small = not card.joker_display_values.small
+            card:update_joker_display(false, false, "Controller:queue_L_cursor_press")
+    
+            if card.children.joker_display then card.children.joker_display:recalculate(true) end
+            if card.children.joker_display_small then card.children.joker_display_small:recalculate(true) end
+            if card.children.joker_display_debuff then card.children.joker_display_debuff:recalculate(true) end
         end
     end
 end

--- a/src/display_functions.lua
+++ b/src/display_functions.lua
@@ -383,9 +383,9 @@ end
 ---@param force_reload boolean? Force re-initialization
 ---@param _from string? Debug string
 function JokerDisplay.update_all_joker_display(force_update, force_reload, _from)
-    if G.jokers then
-        for _, area in ipairs(JokerDisplay.get_display_areas()) do
-            for _, card in pairs(area.cards) do
+    if JokerDisplay.should_display() then
+        for _, area in pairs(JokerDisplay.get_display_areas()) do
+            for _, card in pairs(area.cards or {}) do
                 card:update_joker_display(force_update, force_reload, _from)
             end
         end
@@ -490,10 +490,10 @@ end
 local card_update_ref = Card.update
 function Card:update(dt)
     card_update_ref(self, dt)
-    if JokerDisplay.config.enabled and G.jokers then
+    if JokerDisplay.config.enabled and JokerDisplay.should_display() then
         local is_display_area = false
         if self.area then
-            for _, area in ipairs(JokerDisplay.get_display_areas()) do
+            for _, area in pairs(JokerDisplay.get_display_areas()) do
                 if self.area == area then
                     is_display_area = true
                     break
@@ -538,10 +538,10 @@ end
 local card_set_ability_ref = Card.set_ability
 function Card:set_ability(center, initial, delay_sprites)
     card_set_ability_ref(self, center, initial, delay_sprites)
-    if JokerDisplay.config.enabled and G.jokers and self.joker_display_values then
+    if JokerDisplay.config.enabled and JokerDisplay.should_display() and self.joker_display_values then
         local is_display_area = false
         if self.area then
-            for _, area in ipairs(JokerDisplay.get_display_areas()) do
+            for _, area in pairs(JokerDisplay.get_display_areas()) do
                 if self.area == area then
                     is_display_area = true
                     break

--- a/src/display_functions.lua
+++ b/src/display_functions.lua
@@ -4,6 +4,9 @@
 ---@param custom_parent table? Another card the display should be under
 ---@param stop_calc boolean? Don't call calculate_joker_display
 function Card:initialize_joker_display(custom_parent, stop_calc)
+    self.joker_display_values.blueprint_initialized = false
+    self.joker_display_values.blueprint_loaded = false
+
     if not JokerDisplay.Definitions[self.config.center.key] and
         self.config.center.joker_display_def and type(self.config.center.joker_display_def) == "function" then
         JokerDisplay.Definitions[self.config.center.key] = self.config.center.joker_display_def(JokerDisplay)
@@ -63,8 +66,6 @@ function Card:initialize_joker_display(custom_parent, stop_calc)
                 replace_debuff_text_config)
         end
     end
-
-    self.joker_display_values.blueprint_loaded = false
 
     if replace_modifiers then
         self.children.joker_display.stop_modifiers = true
@@ -491,41 +492,43 @@ local card_update_ref = Card.update
 function Card:update(dt)
     card_update_ref(self, dt)
     if JokerDisplay.config.enabled and JokerDisplay.should_display() then
-        local is_display_area = false
-        if self.area then
-            for _, area in pairs(JokerDisplay.get_display_areas()) do
-                if self.area == area then
-                    is_display_area = true
-                    break
-                end
-            end
-        end
-        if is_display_area then
-            if G.STATE ~= G.STATES.HAND_PLAYED and G.STATE ~= G.STATES.SELECTING_HAND and G.STATE ~= G.STATES.DRAW_TO_HAND then
-                JokerDisplay.current_hand = {}
-                JokerDisplay.current_hand_info = {
-                    text = "Unknown",
-                    poker_hands = {},
-                    scoring_hand = {}
-                }
-            end
-            if not self.joker_display_last_update_time then
+        local amount_of_cards = G.jokers and #G.jokers.cards or 2
+        if not self.joker_display_last_update_time then
+            self.joker_display_last_update_time = 0
+            self.joker_display_update_time_variance = math.random()
+            local joker_number_delta_variance = math.max(0.01, amount_of_cards / 30)
+            self.joker_display_next_update_time = joker_number_delta_variance / 2 +
+                joker_number_delta_variance / 2 * self.joker_display_update_time_variance
+        elseif self.joker_display_values and G.real_dt > 0.05 and amount_of_cards > 20 then
+            self.joker_display_values.disabled = true
+        else
+            self.joker_display_last_update_time = self.joker_display_last_update_time + G.real_dt
+            if self.joker_display_last_update_time > self.joker_display_next_update_time then
                 self.joker_display_last_update_time = 0
-                self.joker_display_update_time_variance = math.random()
-                local joker_number_delta_variance = math.max(0.01, #G.jokers.cards / 20)
+                local joker_number_delta_variance = math.max(0.1, amount_of_cards / 30)
                 self.joker_display_next_update_time = joker_number_delta_variance / 2 +
                     joker_number_delta_variance / 2 * self.joker_display_update_time_variance
-            elseif self.joker_display_values and G.real_dt > 0.05 and #G.jokers.cards > 20 then
-                self.joker_display_values.disabled = true
-            else
-                self.joker_display_last_update_time = self.joker_display_last_update_time + G.real_dt
-                if self.joker_display_last_update_time > self.joker_display_next_update_time then
-                    self.joker_display_last_update_time = 0
-                    local joker_number_delta_variance = math.max(0.1, #G.jokers.cards / 20)
-                    self.joker_display_next_update_time = joker_number_delta_variance / 2 +
-                        joker_number_delta_variance / 2 * self.joker_display_update_time_variance
-                    self:update_joker_display(false, false, "Card:update")
 
+                local is_display_area = false
+                if self.area then
+                    for _, area in pairs(JokerDisplay.get_display_areas()) do
+                        if self.area == area then
+                            is_display_area = true
+                            break
+                        end
+                    end
+                end
+                if is_display_area then
+                    if G.STATE ~= G.STATES.HAND_PLAYED and G.STATE ~= G.STATES.SELECTING_HAND and G.STATE ~= G.STATES.DRAW_TO_HAND then
+                        JokerDisplay.current_hand = {}
+                        JokerDisplay.current_hand_info = {
+                            text = "Unknown",
+                            poker_hands = {},
+                            scoring_hand = {}
+                        }
+                    end
+                    self:update_joker_display(false, false, "Card:update")
+    
                     if self.children.joker_display then self.children.joker_display:recalculate(true) end
                     if self.children.joker_display_small then self.children.joker_display_small:recalculate(true) end
                     if self.children.joker_display_debuff then self.children.joker_display_debuff:recalculate(true) end

--- a/src/display_functions.lua
+++ b/src/display_functions.lua
@@ -48,15 +48,18 @@ function Card:initialize_joker_display(custom_parent, stop_calc)
     end
 
     if not custom_parent then
-        self.children.joker_display:remove_text()
-        self.children.joker_display_small:remove_text()
-        self.children.joker_display:remove_reminder_text()
-        self.children.joker_display_small:remove_reminder_text()
-        self.children.joker_display:remove_extra()
-        self.children.joker_display_small:remove_extra()
-        self.children.joker_display:remove_modifiers()
-        self.children.joker_display_small:remove_modifiers()
-
+        if self.children.joker_display then            
+            self.children.joker_display:remove_text()
+            self.children.joker_display:remove_reminder_text()
+            self.children.joker_display:remove_extra()
+            self.children.joker_display:remove_modifiers()
+        end
+        if self.children.joker_display_small then            
+            self.children.joker_display_small:remove_text()
+            self.children.joker_display_small:remove_reminder_text()
+            self.children.joker_display_small:remove_extra()
+            self.children.joker_display_small:remove_modifiers()
+        end
         if self.children.joker_display_debuff then
             self.children.joker_display_debuff:remove_modifiers()
             self.children.joker_display_debuff:remove_text()
@@ -67,18 +70,14 @@ function Card:initialize_joker_display(custom_parent, stop_calc)
         end
     end
 
-    if replace_modifiers then
-        self.children.joker_display.stop_modifiers = true
-        self.children.joker_display_small.stop_modifiers = true
-        if self.children.joker_display_debuff then
-            self.children.joker_display_debuff.stop_modifiers = true
-        end
-    else
-        self.children.joker_display.stop_modifiers = false
-        self.children.joker_display_small.stop_modifiers = false
-        if self.children.joker_display_debuff then
-            self.children.joker_display_debuff.stop_modifiers = false
-        end
+    if self.children.joker_display then
+        self.children.joker_display.stop_modifiers = not not replace_modifiers
+    end
+    if self.children.joker_display_small then
+        self.children.joker_display_small.stop_modifiers = not not replace_modifiers
+    end
+    if self.children.joker_display_debuff then
+        self.children.joker_display_debuff.stop_modifiers = not not replace_modifiers
     end
 
     if self.children.joker_display_debuff then
@@ -110,13 +109,15 @@ function Card:initialize_joker_display(custom_parent, stop_calc)
     local definition_extra = replace_extra or joker_display_definition and joker_display_definition.extra
     local extra_config = replace_extra_config or joker_display_definition and joker_display_definition.extra_config
 
+    local update_target_element = custom_parent or self
+    local update_parent = custom_parent and self or nil
+
     if definition_text then
-        if custom_parent then
-            custom_parent.children.joker_display:add_text(definition_text, text_config, self)
-            custom_parent.children.joker_display_small:add_text(definition_text, text_config, self)
-        else
-            self.children.joker_display:add_text(definition_text, text_config)
-            self.children.joker_display_small:add_text(definition_text, text_config)
+        if update_target_element.children.joker_display then
+            update_target_element.children.joker_display:add_text(definition_text, text_config, update_parent)
+        end
+        if update_target_element.children.joker_display_small then
+            update_target_element.children.joker_display_small:add_text(definition_text, text_config, update_parent)
         end
     end
     if definition_reminder_text then
@@ -126,51 +127,37 @@ function Card:initialize_joker_display(custom_parent, stop_calc)
         reminder_text_config.colour = reminder_text_config.colour or G.C.UI.TEXT_INACTIVE
         reminder_text_config.scale = reminder_text_config.scale or 0.3
         if JokerDisplay.config.default_rows.reminder then
-            if custom_parent then
-                custom_parent.children.joker_display:add_reminder_text(definition_reminder_text, reminder_text_config,
-                    self)
-            else
-                self.children.joker_display:add_reminder_text(definition_reminder_text, reminder_text_config)
+            if update_target_element.children.joker_display then                    
+                update_target_element.children.joker_display:add_reminder_text(definition_reminder_text, reminder_text_config, update_parent)
             end
         end
         if JokerDisplay.config.small_rows.reminder then
-            if custom_parent then
-                custom_parent.children.joker_display_small:add_reminder_text(definition_reminder_text,
-                    reminder_text_config, self)
-            else
-                self.children.joker_display_small:add_reminder_text(definition_reminder_text, reminder_text_config)
+            if update_target_element.children.joker_display_small then                    
+                update_target_element.children.joker_display_small:add_reminder_text(definition_reminder_text, reminder_text_config, update_parent)
             end
         end
     end
     if definition_extra then
         if JokerDisplay.config.default_rows.extra then
-            if custom_parent then
-                custom_parent.children.joker_display:add_extra(definition_extra, extra_config, self)
-            else
-                self.children.joker_display:add_extra(definition_extra, extra_config)
+            if update_target_element.children.joker_display then
+                update_target_element.children.joker_display:add_extra(definition_extra, extra_config, update_parent)
             end
         end
         if JokerDisplay.config.small_rows.extra then
-            if custom_parent then
-                custom_parent.children.joker_display_small:add_extra(definition_extra, extra_config, self)
-            else
-                self.children.joker_display_small:add_extra(definition_extra, extra_config)
+            if update_target_element.children.joker_display_small then
+                update_target_element.children.joker_display_small:add_extra(definition_extra, extra_config, update_parent)
             end
         end
     end
 
-    if custom_parent then
-        custom_parent.children.joker_display:recalculate(true, true)
-        custom_parent.children.joker_display_small:recalculate(true, true)
-        if custom_parent.children.joker_display_debuff then
-            custom_parent.children.joker_display_debuff:recalculate(true, true)
-        end
-    else
-        self.children.joker_display:recalculate(true, true)
-        self.children.joker_display_small:recalculate(true, true)
-        if self.children.joker_display_debuff then
-            self.children.joker_display_debuff:recalculate(true, true)
-        end
+    if update_target_element.children.joker_display then
+        update_target_element.children.joker_display:recalculate(true, true)
+    end
+    if update_target_element.children.joker_display_small then
+        update_target_element.children.joker_display_small:recalculate(true, true)
+    end
+    if update_target_element.children.joker_display_debuff then
+        update_target_element.children.joker_display_debuff:recalculate(true, true)
     end
 end
 
@@ -221,7 +208,7 @@ function Card:calculate_joker_display(custom_parent)
         end
 
         if JokerDisplay.config.default_rows.modifiers and not self.joker_display_stop_calc then
-            if not self.children.joker_display.stop_modifiers then
+            if self.children.joker_display and not self.children.joker_display.stop_modifiers then
                 self.children.joker_display:change_modifiers(JokerDisplay.calculate_joker_modifiers(self), true)
             end
             if self.children.joker_display_debuff and not self.children.joker_display_debuff.stop_modifiers then
@@ -229,7 +216,7 @@ function Card:calculate_joker_display(custom_parent)
             end
         end
 
-        if JokerDisplay.config.small_rows.modifiers and not self.children.joker_display_small.stop_modifiers and not self.joker_display_stop_calc then
+        if JokerDisplay.config.small_rows.modifiers and self.children.joker_display_small and not self.children.joker_display_small.stop_modifiers and not self.joker_display_stop_calc then
             self.children.joker_display_small:change_modifiers(JokerDisplay.calculate_joker_modifiers(self), true)
         end
     end
@@ -358,11 +345,33 @@ function Card:update_joker_display(force_update, force_reload, _from)
             should_reload = true
         end
 
+        local should_display_small = self.joker_display_values.small
+        if should_display_small then
+            if self.children.joker_display then
+                self.children.joker_display:remove()
+                self.children.joker_display = nil
+                should_reload = true
+            end
+            if not self.children.joker_display_small then
+                self.children.joker_display_small = JokerDisplayBox(self, "joker_display_small_enable", { type = "SMALL" })
+                should_reload = true
+            end
+        else
+            if self.children.joker_display_small then
+                self.children.joker_display_small:remove()
+                self.children.joker_display_small = nil
+                should_reload = true
+            end
+            if not self.children.joker_display then
+                self.children.joker_display = JokerDisplayBox(self, "joker_display_disable", { type = "NORMAL" })
+                should_reload = true
+            end
+        end
+
         --print(tostring(self.ability.name) .. " : " .. tostring(_from))
-        if not self.children.joker_display then
+        if not self.joker_display_installed then
+            self.joker_display_installed = true
             --Regular Display
-            self.children.joker_display = JokerDisplayBox(self, "joker_display_disable", { type = "NORMAL" })
-            self.children.joker_display_small = JokerDisplayBox(self, "joker_display_small_enable", { type = "SMALL" })
             should_reload = true
         else
             if force_update or (JokerDisplay.config.enabled and (not self.joker_display_values.disabled or self.joker_display_values.blueprint_force_update)) then
@@ -375,6 +384,10 @@ function Card:update_joker_display(force_update, force_reload, _from)
         end
         if should_reload then
             self:initialize_joker_display()
+            self:calculate_joker_display()
+            if self.children.joker_display then self.children.joker_display:recalculate(true) end
+            if self.children.joker_display_small then self.children.joker_display_small:recalculate(true) end
+            if self.children.joker_display_debuff then self.children.joker_display_debuff:recalculate(true) end
         end
     end
 end

--- a/src/display_functions.lua
+++ b/src/display_functions.lua
@@ -355,11 +355,6 @@ function Card:update_joker_display(force_update, force_reload, _from)
 
         --print(tostring(self.ability.name) .. " : " .. tostring(_from))
         if not self.children.joker_display then
-            self.joker_display_values = {
-                disabled = JokerDisplay.config.hide_by_default or false,
-                small = false,
-            }
-
             --Regular Display
             self.children.joker_display = JokerDisplayBox(self, "joker_display_disable", { type = "NORMAL" })
             self.children.joker_display_small = JokerDisplayBox(self, "joker_display_small_enable", { type = "SMALL" })

--- a/src/display_functions.lua
+++ b/src/display_functions.lua
@@ -230,6 +230,95 @@ end
 ---@param _from string? Debug string
 function Card:update_joker_display(force_update, force_reload, _from)
     if self.ability then
+
+        --Perishable display
+        local should_display_perishable = self.ability.perishable
+            and self.facing ~= 'back'
+            and JokerDisplay.config.enabled
+            and not (self.joker_display_values or {}).disabled
+            and not JokerDisplay.config.disable_perishable
+
+        if should_display_perishable and not self.children.joker_display_perishable then
+            self.children.joker_display_perishable = UIBox {
+                definition = {
+                    n = G.UIT.ROOT,
+                    config = {
+                        minh = 0.5,
+                        maxh = 0.5,
+                        minw = 0.75,
+                        maxw = 0.75,
+                        r = 0.001,
+                        padding = 0.1,
+                        align = 'cm',
+                        colour = adjust_alpha(darken(G.C.BLACK, 0.2), 0.8),
+                        shadow = false,
+                        ref_table = self
+                    },
+                    nodes = {
+                        JokerDisplay.create_display_text_object({
+                            ref_table = self.joker_display_values, ref_value = "perishable",
+                            colour = lighten(G.C.PERISHABLE, 0.35), scale = 0.35
+                        })
+                    }
+                },
+                config = {
+                    align = "tl",
+                    bond = 'Strong',
+                    parent = self,
+                    offset = { x = 0.8, y = 0 },
+                },
+            }
+            self.children.joker_display_perishable.states.collide.can = true
+            self.children.joker_display_perishable.name = "JokerDisplay"
+        elseif not should_display_perishable and self.children.joker_display_perishable then
+            self.children.joker_display_perishable:remove()
+            self.children.joker_display_perishable = nil
+        end
+
+        --Rental display
+        local should_display_rental = self.ability.rental
+            and JokerDisplay.config.enabled
+            and self.facing ~= 'back'
+            and not (self.joker_display_values or {}).disabled
+            and not JokerDisplay.config.disable_rental
+
+        if should_display_rental and not self.children.joker_display_rental then
+            self.children.joker_display_rental = UIBox {
+                definition = {
+                    n = G.UIT.ROOT,
+                    config = {
+                        minh = 0.5,
+                        maxh = 0.5,
+                        minw = 0.75,
+                        maxw = 0.75,
+                        r = 0.001,
+                        padding = 0.1,
+                        align = 'cm',
+                        colour = adjust_alpha(darken(G.C.BLACK, 0.2), 0.8),
+                        shadow = false,
+                        ref_table = self
+                    },
+                    nodes = {
+                        JokerDisplay.create_display_text_object({
+                            ref_table = self.joker_display_values, ref_value = "rental",
+                            colour = G.C.GOLD, scale = 0.35
+                        })
+                    }
+                },
+                config = {
+                    align = "tr",
+                    bond = 'Strong',
+                    parent = self,
+                    offset = { x = -0.8, y = 0 },
+                },
+            }
+            self.children.joker_display_rental.states.collide.can = true
+            self.children.joker_display_rental.name = "JokerDisplay"
+        elseif not should_display_rental and self.children.joker_display_rental then
+            self.children.joker_display_rental:remove()
+            self.children.joker_display_rental = nil
+        end
+
         --print(tostring(self.ability.name) .. " : " .. tostring(_from))
         if not self.children.joker_display then
             self.joker_display_values = {}
@@ -241,88 +330,6 @@ function Card:update_joker_display(force_update, force_reload, _from)
             self.children.joker_display_small = JokerDisplayBox(self, "joker_display_small_enable", { type = "SMALL" })
             self.children.joker_display_debuff = JokerDisplayBox(self, "joker_display_debuff", { type = "DEBUFF" })
             self:initialize_joker_display()
-
-            --Perishable Display
-            self.config.joker_display_perishable = {
-                n = G.UIT.ROOT,
-                config = {
-                    minh = 0.5,
-                    maxh = 0.5,
-                    minw = 0.75,
-                    maxw = 0.75,
-                    r = 0.001,
-                    padding = 0.1,
-                    align = 'cm',
-                    colour = adjust_alpha(darken(G.C.BLACK, 0.2), 0.8),
-                    shadow = false,
-                    func = 'joker_display_perishable',
-                    ref_table = self
-                },
-                nodes = {
-                    {
-                        n = G.UIT.R,
-                        config = { align = "cm" },
-                        nodes = { { n = G.UIT.R, config = { align = "cm" }, nodes = { JokerDisplay.create_display_text_object({ ref_table = self.joker_display_values, ref_value = "perishable", colour = lighten(G.C.PERISHABLE, 0.35), scale = 0.35 }) } } }
-                    }
-
-                }
-            }
-
-            self.config.joker_display_perishable_config = {
-                align = "tl",
-                bond = 'Strong',
-                parent = self,
-                offset = { x = 0.8, y = 0 },
-            }
-            if self.config.joker_display_perishable then
-                self.children.joker_display_perishable = UIBox {
-                    definition = self.config.joker_display_perishable,
-                    config = self.config.joker_display_perishable_config,
-                }
-                self.children.joker_display_perishable.states.collide.can = true
-                self.children.joker_display_perishable.name = "JokerDisplay"
-            end
-
-            --Rental Display
-            self.config.joker_display_rental = {
-                n = G.UIT.ROOT,
-                config = {
-                    minh = 0.5,
-                    maxh = 0.5,
-                    minw = 0.75,
-                    maxw = 0.75,
-                    r = 0.001,
-                    padding = 0.1,
-                    align = 'cm',
-                    colour = adjust_alpha(darken(G.C.BLACK, 0.2), 0.8),
-                    shadow = false,
-                    func = 'joker_display_rental',
-                    ref_table = self
-                },
-                nodes = {
-                    {
-                        n = G.UIT.R,
-                        config = { align = "cm" },
-                        nodes = { { n = G.UIT.R, config = { align = "cm" }, nodes = { JokerDisplay.create_display_text_object({ ref_table = self.joker_display_values, ref_value = "rental", colour = G.C.GOLD, scale = 0.35 }) } } }
-                    }
-
-                }
-            }
-
-            self.config.joker_display_rental_config = {
-                align = "tr",
-                bond = 'Strong',
-                parent = self,
-                offset = { x = -0.8, y = 0 },
-            }
-            if self.config.joker_display_rental then
-                self.children.joker_display_rental = UIBox {
-                    definition = self.config.joker_display_rental,
-                    config = self.config.joker_display_rental_config,
-                }
-                self.children.joker_display_rental.states.collide.can = true
-                self.children.joker_display_rental.name = "JokerDisplay"
-            end
         else
             if force_update or (JokerDisplay.config.enabled and (not self.joker_display_values.disabled or self.joker_display_values.blueprint_force_update)) then
                 if force_reload then
@@ -413,32 +420,6 @@ G.FUNCS.joker_display_debuff = function(e)
     if not (card.facing == 'back') and card.debuff then
         e.states.visible = JokerDisplay.config.enabled and not card.joker_display_values.disabled
         e.parent.states.collide.can = JokerDisplay.config.enabled and not card.joker_display_values.disabled
-    else
-        e.states.visible = false
-        e.parent.states.collide.can = false
-    end
-end
-
-G.FUNCS.joker_display_perishable = function(e)
-    local card = e.config.ref_table
-    if not (card.facing == 'back') and card.ability.perishable then
-        e.states.visible = JokerDisplay.config.enabled and not card.joker_display_values.disabled and
-            not JokerDisplay.config.disable_perishable
-        e.parent.states.collide.can = JokerDisplay.config.enabled and not card.joker_display_values.disabled and
-            not JokerDisplay.config.disable_perishable
-    else
-        e.states.visible = false
-        e.parent.states.collide.can = false
-    end
-end
-
-G.FUNCS.joker_display_rental = function(e)
-    local card = e.config.ref_table
-    if not (card.facing == 'back') and card.ability.rental then
-        e.states.visible = JokerDisplay.config.enabled and not card.joker_display_values.disabled and
-            not JokerDisplay.config.disable_rental
-        e.parent.states.collide.can = JokerDisplay.config.enabled and not card.joker_display_values.disabled and
-            not JokerDisplay.config.disable_rental
     else
         e.states.visible = false
         e.parent.states.collide.can = false

--- a/src/display_functions.lua
+++ b/src/display_functions.lua
@@ -53,29 +53,39 @@ function Card:initialize_joker_display(custom_parent, stop_calc)
         self.children.joker_display_small:remove_extra()
         self.children.joker_display:remove_modifiers()
         self.children.joker_display_small:remove_modifiers()
-        self.children.joker_display_debuff:remove_modifiers()
-        self.children.joker_display_debuff:remove_text()
 
-        self.children.joker_display_debuff:add_text(
-            replace_debuff_text or { { text = "" .. localize("k_debuffed"), colour = G.C.UI.TEXT_INACTIVE } },
-            replace_debuff_text_config)
+        if self.children.joker_display_debuff then
+            self.children.joker_display_debuff:remove_modifiers()
+            self.children.joker_display_debuff:remove_text()
+
+            self.children.joker_display_debuff:add_text(
+                replace_debuff_text or { { text = "" .. localize("k_debuffed"), colour = G.C.UI.TEXT_INACTIVE } },
+                replace_debuff_text_config)
+        end
     end
     if replace_modifiers then
         self.children.joker_display.stop_modifiers = true
         self.children.joker_display_small.stop_modifiers = true
-        self.children.joker_display_debuff.stop_modifiers = true
+        if self.children.joker_display_debuff then
+            self.children.joker_display_debuff.stop_modifiers = true
+        end
     else
         self.children.joker_display.stop_modifiers = false
         self.children.joker_display_small.stop_modifiers = false
-        self.children.joker_display_debuff.stop_modifiers = false
+        if self.children.joker_display_debuff then
+            self.children.joker_display_debuff.stop_modifiers = false
+        end
     end
-    self.children.joker_display_debuff:remove_reminder_text()
-    if replace_debuff_reminder then
-        self.children.joker_display_debuff:add_reminder_text(replace_debuff_reminder, replace_debuff_reminder_config)
-    end
-    self.children.joker_display_debuff:remove_extra()
-    if replace_debuff_extra then
-        self.children.joker_display_debuff:add_extra(replace_debuff_extra, replace_debuff_extra_config)
+
+    if self.children.joker_display_debuff then
+        self.children.joker_display_debuff:remove_reminder_text()
+        if replace_debuff_reminder then
+            self.children.joker_display_debuff:add_reminder_text(replace_debuff_reminder, replace_debuff_reminder_config)
+        end
+        self.children.joker_display_debuff:remove_extra()
+        if replace_debuff_extra then
+            self.children.joker_display_debuff:add_extra(replace_debuff_extra, replace_debuff_extra_config)
+        end
     end
 
     self.joker_display_stop_calc = replace_stop_calc
@@ -148,11 +158,15 @@ function Card:initialize_joker_display(custom_parent, stop_calc)
     if custom_parent then
         custom_parent.children.joker_display:recalculate(true, true)
         custom_parent.children.joker_display_small:recalculate(true, true)
-        custom_parent.children.joker_display_debuff:recalculate(true, true)
+        if custom_parent.children.joker_display_debuff then
+            custom_parent.children.joker_display_debuff:recalculate(true, true)
+        end
     else
         self.children.joker_display:recalculate(true, true)
         self.children.joker_display_small:recalculate(true, true)
-        self.children.joker_display_debuff:recalculate(true, true)
+        if self.children.joker_display_debuff then
+            self.children.joker_display_debuff:recalculate(true, true)
+        end
     end
 end
 
@@ -206,7 +220,7 @@ function Card:calculate_joker_display(custom_parent)
             if not self.children.joker_display.stop_modifiers then
                 self.children.joker_display:change_modifiers(JokerDisplay.calculate_joker_modifiers(self), true)
             end
-            if not self.children.joker_display_debuff.stop_modifiers then
+            if self.children.joker_display_debuff and not self.children.joker_display_debuff.stop_modifiers then
                 self.children.joker_display_debuff:change_modifiers(JokerDisplay.calculate_joker_modifiers(self), true)
             end
         end
@@ -230,6 +244,10 @@ end
 ---@param _from string? Debug string
 function Card:update_joker_display(force_update, force_reload, _from)
     if self.ability then
+        self.joker_display_values = self.joker_display_values or {
+            disabled = JokerDisplay.config.hide_by_default or false,
+            small = false,
+        }
 
         --Perishable display
         local should_display_perishable = self.ability.perishable
@@ -319,25 +337,44 @@ function Card:update_joker_display(force_update, force_reload, _from)
             self.children.joker_display_rental = nil
         end
 
+        local should_reload = false
+
+        local should_display_debuff = self.debuff
+            and self.facing ~= "back"
+            and JokerDisplay.config.enabled
+            and not (self.joker_display_values or {}).disabled
+
+        if should_display_debuff and not self.children.joker_display_debuff then
+            self.children.joker_display_debuff = JokerDisplayBox(self, nil, { type = "DEBUFF" })
+            self.children.joker_display_debuff.states.collide.can = false
+            should_reload = true
+        elseif not should_display_debuff and self.children.joker_display_debuff then
+            self.children.joker_display_debuff:remove()
+            self.children.joker_display_debuff = nil
+        end
+
         --print(tostring(self.ability.name) .. " : " .. tostring(_from))
         if not self.children.joker_display then
-            self.joker_display_values = {}
-            self.joker_display_values.disabled = JokerDisplay.config.hide_by_default or false
-            self.joker_display_values.small = false
+            self.joker_display_values = {
+                disabled = JokerDisplay.config.hide_by_default or false,
+                small = false,
+            }
 
             --Regular Display
             self.children.joker_display = JokerDisplayBox(self, "joker_display_disable", { type = "NORMAL" })
             self.children.joker_display_small = JokerDisplayBox(self, "joker_display_small_enable", { type = "SMALL" })
-            self.children.joker_display_debuff = JokerDisplayBox(self, "joker_display_debuff", { type = "DEBUFF" })
-            self:initialize_joker_display()
+            should_reload = true
         else
             if force_update or (JokerDisplay.config.enabled and (not self.joker_display_values.disabled or self.joker_display_values.blueprint_force_update)) then
                 if force_reload then
-                    self:initialize_joker_display()
+                    should_reload = true
                 else
                     self:calculate_joker_display()
                 end
             end
+        end
+        if should_reload then
+            self:initialize_joker_display()
         end
     end
 end
@@ -411,18 +448,6 @@ G.FUNCS.joker_display_small_enable = function(e)
     else
         e.states.visible = JokerDisplay.config.enabled and not card.joker_display_values.disabled
         e.parent.states.collide.can = JokerDisplay.config.enabled and not card.joker_display_values.disabled
-    end
-end
-
-
-G.FUNCS.joker_display_debuff = function(e)
-    local card = e.config.ref_table
-    if not (card.facing == 'back') and card.debuff then
-        e.states.visible = JokerDisplay.config.enabled and not card.joker_display_values.disabled
-        e.parent.states.collide.can = JokerDisplay.config.enabled and not card.joker_display_values.disabled
-    else
-        e.states.visible = false
-        e.parent.states.collide.can = false
     end
 end
 

--- a/src/display_functions.lua
+++ b/src/display_functions.lua
@@ -63,6 +63,9 @@ function Card:initialize_joker_display(custom_parent, stop_calc)
                 replace_debuff_text_config)
         end
     end
+
+    self.joker_display_values.blueprint_loaded = false
+
     if replace_modifiers then
         self.children.joker_display.stop_modifiers = true
         self.children.joker_display_small.stop_modifiers = true
@@ -351,6 +354,7 @@ function Card:update_joker_display(force_update, force_reload, _from)
         elseif not should_display_debuff and self.children.joker_display_debuff then
             self.children.joker_display_debuff:remove()
             self.children.joker_display_debuff = nil
+            should_reload = true
         end
 
         --print(tostring(self.ability.name) .. " : " .. tostring(_from))

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -98,11 +98,15 @@ function JokerDisplay.number_format(num, e_switch_point, places)
     return sign .. (formatted:reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse())
 end
 
+function JokerDisplay.should_display()
+    return (G.jokers or G.jokerdisplay_config_card_area) and true or false
+end
+
 ---Get all areas available for JokerDisplay \
 ---Hook to add more areas
 ---@return table
 function JokerDisplay.get_display_areas()
-    return { G.jokers }
+    return { G.jokers, G.jokerdisplay_config_card_area }
 end
 
 ---Checks if a value is in a table. Used as a drop in replacement to SMODS.in_scoring


### PR DESCRIPTION
- UI for rentals and perishables created only when respective stickers applied
- Debuff UI created only when joker is debuffed, and removed afterwards
- Main and small UI replace each other depending on settings
- Update interval for values decreased to 2/3 of initial value
- In result, amount of moveables per joker decreased up to 70% (in case of non-perishable non-rental non-debuffed joker)