### PR TITLE
Fix e_mult modifier multiplication in calculate_joker_modifiers

### DIFF
--- a/src/api_helper_functions.lua
+++ b/src/api_helper_functions.lua
@@ -282,7 +282,7 @@ JokerDisplay.calculate_joker_modifiers = function(card)
                     edition_mods.x_mult or modifiers.x_mult,
                 dollars = (modifiers.dollars and edition_mods.dollars and modifiers.dollars + edition_mods.dollars) or
                     edition_mods.dollars or modifiers.dollars,
-                e_mult = (modifiers.e_mult and edition_mods.e_mult and modifiers.e_mult ^ edition_mods.e_mult) or
+                e_mult = (modifiers.e_mult and edition_mods.e_mult and modifiers.e_mult * edition_mods.e_mult) or
                     edition_mods.e_mult or modifiers.e_mult,
             }
         end
@@ -317,7 +317,7 @@ JokerDisplay.calculate_joker_modifiers = function(card)
                             extra_mods.x_mult or modifiers.x_mult,
                         dollars = (modifiers.dollars and extra_mods.dollars and modifiers.dollars + extra_mods.dollars) or
                             extra_mods.dollars or modifiers.dollars,
-                        e_mult = (modifiers.e_mult and extra_mods.e_mult and modifiers.e_mult ^ extra_mods.e_mult) or
+                        e_mult = (modifiers.e_mult and extra_mods.e_mult and modifiers.e_mult * extra_mods.e_mult) or
                             extra_mods.e_mult or modifiers.e_mult,
                     }
                 end


### PR DESCRIPTION
### Summary of Changes
Fixed `e_mult` combination logic in `JokerDisplay.calculate_joker_modifiers` (`src/api_helper_functions.lua`).

### Problem
Previously, consecutive `e_mult` modifiers (such as from custom editions and mod functions) were combined using exponentiation (`modifiers.e_mult ^ extra_mods.e_mult`). For example, combining `^1.1` and `^1.2` resulted in `1.1 ^ 1.2 ≈ 1.1213`.

### Solution
Mathematically, consecutive power multipliers compose as powers of powers: $(M^a)^b = M^{a \times b}$. The exponent values should be multiplied rather than exponentiated.
Changed `^` to `*` for `e_mult` calculations so that `^1.1` and `^1.2` correctly combine to `^1.32` ($1.1 \times 1.2$).
