### PR TITLE
Show Misprint's top-of-deck card, with a config toggle

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -11,6 +11,7 @@ return {
 	disable_collapse = false,
 	disable_perishable = false,
 	disable_rental = false,
+	disable_misprint_top_card = false,
 	small_rows = {
 		reminder = false,
 		extra = false,

--- a/definitions/display_definitions.lua
+++ b/definitions/display_definitions.lua
@@ -502,7 +502,36 @@ return {
                     min_cycle_time = 0
                 }
             }
-        }
+        },
+        reminder_text = {
+            { ref_table = "card.joker_display_values", ref_value = "top_card", colour = G.C.FILTER },
+        },
+        calc_function = function(card)
+            card.joker_display_values.top_card = ""
+            card.joker_display_values.top_card_suit = nil
+            if JokerDisplay.config.disable_misprint_top_card then return end
+
+            local top_card = G.deck and G.deck.cards and G.deck.cards[#G.deck.cards]
+            if top_card and top_card.base and top_card.base.suit and top_card.base.value then
+                card.joker_display_values.top_card_suit = top_card.base.suit
+                card.joker_display_values.top_card = localize {
+                    type = 'variable',
+                    key = "jdis_top_card",
+                    vars = {
+                        localize {
+                            type = 'variable',
+                            key = "jdis_rank_of_suit",
+                            vars = { localize(top_card.base.value, 'ranks'), localize(top_card.base.suit, 'suits_plural') }
+                        }
+                    }
+                }
+            end
+        end,
+        style_function = function(card, text, reminder_text, extra)
+            if reminder_text and reminder_text.children and reminder_text.children[1] and card.joker_display_values.top_card_suit then
+                reminder_text.children[1].config.colour = lighten(G.C.SUITS[card.joker_display_values.top_card_suit], 0.35)
+            end
+        end
     },
     j_dusk = { -- Dusk
         reminder_text = {

--- a/localization/default.lua
+++ b/localization/default.lua
@@ -36,6 +36,7 @@ return {
 			jdis_disable_collapse = "Disable collapsing",
 			jdis_disable_perishable = "Disable Perishable",
 			jdis_disable_rental = "Disable Rental",
+			jdis_disable_misprint_top_card = "Disable Misprint Top Card",
 			jdis_modifiers = "Modifiers",
 			jdis_reminders = "Reminders",
 			jdis_extras = "Extras",
@@ -48,7 +49,8 @@ return {
 		},
 		v_dictionary = {
 			jdis_odds = "#1# in #2#",
-			jdis_rank_of_suit = "#1# of #2#"
+			jdis_rank_of_suit = "#1# of #2#",
+			jdis_top_card = "(Top card: #1#)"
 		}
 	},
 }

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -36,6 +36,7 @@ return {
 			jdis_disable_collapse = "Disable collapsing",
 			jdis_disable_perishable = "Disable Perishable",
 			jdis_disable_rental = "Disable Rental",
+			jdis_disable_misprint_top_card = "Disable Misprint Top Card",
 			jdis_modifiers = "Modifiers",
 			jdis_reminders = "Reminders",
 			jdis_extras = "Extras",
@@ -48,7 +49,8 @@ return {
 		},
 		v_dictionary = {
 			jdis_odds = "#1# in #2#",
-			jdis_rank_of_suit = "#1# of #2#"
+			jdis_rank_of_suit = "#1# of #2#",
+			jdis_top_card = "(Top card: #1#)"
 		}
 	},
 }

--- a/src/config_tab.lua
+++ b/src/config_tab.lua
@@ -160,6 +160,19 @@ JokerDisplay.config_tab = function()
                                 })
                             }
                         },
+                        {
+                            n = G.UIT.R,
+                            config = { padding = 0.01, align = "cr" },
+                            nodes = {
+                                create_toggle({
+                                    label = localize('jdis_disable_misprint_top_card'),
+                                    ref_table = JokerDisplay.config,
+                                    ref_value =
+                                    'disable_misprint_top_card',
+                                    callback = JokerDisplay.save_config
+                                })
+                            }
+                        },
                     }
                 },
             }


### PR DESCRIPTION
## What changed

Misprint's tooltip has a known quirk where, among the random mult values it cycles through, it also reveals the top card of the deck. This adds that as an explicit reminder line under Misprint in JokerDisplay:

> **(Top card: King of Spades)**

colored to match the card's suit, consistent with the existing Idol/Ancient Joker/Castle/Mail-In Rebate card reminders.

## Why

A user asked for Misprint's JokerDisplay entry to surface the top-of-deck info the way the community "TopCardPreview" lovely mod does, instead of relying on that separate mod.

## Details

- `definitions/display_definitions.lua`: `j_misprint`'s `calc_function` now reads `G.deck.cards[#G.deck.cards]` (the top card) each calc cycle and localizes it into the reminder text; a `style_function` colors it by suit.
- Added a **"Disable Misprint Top Card"** toggle (`src/config_tab.lua`, `config.lua`) so the feature can be turned off — default is on (shown). The reminder text is implemented as a single `ref_table`/`ref_value`-bound node (rather than static parens + a value node) so that blanking its value on disable collapses the row's width to zero instead of leaving stray empty parentheses behind.
- `localization/default.lua` & `en-us.lua`: new `jdis_top_card` and `jdis_disable_misprint_top_card` strings. Other locale files aren't touched — they already fall back to these per this mod's existing localization merge behavior (confirmed several other locale files are missing recently-added keys like `jdis_rank_of_suit` and work fine).

## Notes for reviewers

- Not tested in a live game session — worth a quick playtest to confirm the reminder line appears/disappears correctly and the toggle collapses the row cleanly with no gap.
- Follows the existing "rank of suit" reminder-text convention already used by Idol/Ancient Joker/Castle/Mail-In Rebate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)